### PR TITLE
Fix problems running eki in a UTF-8 locale

### DIFF
--- a/cdetect.sh
+++ b/cdetect.sh
@@ -8,7 +8,7 @@ function uncompress_kernel()
     size=$(stat -c '%s' "$image")
 
     echo_debug "Size: ${size}bytes, Rewind Offset: ${pos}bytes"
-    if [ -z $pos -o -z $size ]; then
+    if [ -z "$pos" -o -z "$size" ]; then
         echo_error "Compressed kernel image not found"
         return 1
     fi

--- a/eki
+++ b/eki
@@ -55,7 +55,8 @@ function echo_error() { builtin echo "-E- $@" >&2; }
 function echo() { builtin echo "-I- $@" >&2; }
 
 # use grep to search for compression signature
-function find_position() { grep -Pabo $1 "$2" 2>/dev/null; }
+# use "C" locale to avoid interpreting as UTF-8 sequences
+function find_position() { LC_ALL=C grep -Pabo $1 "$2" 2>/dev/null; }
 
 # temp file
 function xmktemp()

--- a/eki
+++ b/eki
@@ -155,7 +155,7 @@ function uncompress_kernel()
     size=$(stat -c '%s' "$image")
 
     echo_debug "Size: ${size}bytes, Rewind Offset: ${pos}bytes"
-    if [ -z $pos -o -z $size ]; then
+    if [ -z "$pos" -o -z "$size" ]; then
         echo_error "Compressed kernel image not found"
         return 1
     fi

--- a/helper.sh
+++ b/helper.sh
@@ -32,7 +32,8 @@ function echo_error() { builtin echo "-E- $@" >&2; }
 function echo() { builtin echo "-I- $@" >&2; }
 
 # use grep to search for compression signature
-function find_position() { grep -Pabo $1 "$2" 2>/dev/null; }
+# use "C" locale to avoid interpreting as UTF-8 sequences
+function find_position() { LC_ALL=C grep -Pabo $1 "$2" 2>/dev/null; }
 
 # temp file
 function xmktemp()


### PR DESCRIPTION
Fix a couple of problems.
1. If `uncompress_kernel` sets `pos` to an empty string due to failing to find the _gzip_ signature, the `[ -z $pos -o -z $size ]` command fails with the error "too many arguments". Quote the arguments to fix it.
2. In `find_position`, the `grep` command will fail to find binary signatures if run in a UTF-8 locale. Force it to run in the "C" locale to fix it.
